### PR TITLE
Feat/devops integrate travis ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,4 +184,4 @@ $RECYCLE.BIN/
 
 server/dist/
 server/mongo-dev/
-
+mongo-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+dist: trusty
+sudo: required
+
+language: minimal
+
+services:
+  - docker
+
+env:
+  - DOCKER_COMPOSE_VERSION=1.19.0
+
+addons:
+  apt:
+    packages:
+      - docker-ce
+
+before_install:
+  - sudo rm -rf /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin/
+  - sudo apt-get -q update
+  - sudo apt-get install -qy make apt-transport-https ca-certificates curl software-properties-common gawk jq parallel curl
+
+before_script:
+  - uname -a
+  - type -a docker-compose && docker-compose version
+  - docker version
+
+script:
+  - ( git fetch --unshallow || true ) && git tag -l
+  - echo "# build & run api in dev mode"
+  - ( cd server && docker-compose -f docker-compose.dev.yml build )
+  - docker images
+  - ( cd server && docker-compose -f docker-compose.dev.yml up -d --no-build )
+  - docker ps
+  - echo "# test-up"
+  - ( cd server && docker-compose -f docker-compose.dev.yml exec -T api npm test )
+  - ( cd server && docker-compose -f docker-compose.dev.yml down )
+after_script:
+  - echo "END"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,60 @@
+#######################
+# Step 1: Base target #
+#######################
+FROM node:10-slim as base
+ARG proxy
+ARG npm_registry
+ARG no_proxy
+
+# Base dir /app
+WORKDIR /app
+# Expose the listening port of your app
+EXPOSE 8000
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo "Europe/Paris" > /etc/timezone
+# use proxy & private npm registry
+RUN if [ ! -z "$proxy" ] ; then \
+        npm config delete proxy; \
+        npm config set proxy $proxy; \
+        npm config set https-proxy $proxy ; \
+        npm config set no-proxy $no_proxy; \
+   fi ; \
+   [ -z "$npm_registry" ] || npm config set registry=$npm_registry
+
+################################
+# Step 2: "development" target #
+################################
+FROM base as development
+COPY src src/
+COPY babel.config.js package.json package-lock.json ./
+# Install app dependencies
+RUN npm install
+
+CMD ["npm", "start"]
+
+##########################
+# Step 3: "build" target #
+##########################
+FROM development as build
+ENV NPM_CONFIG_LOGLEVEL warn
+# Transpile the code with babel
+RUN npm run build
+
+###############################
+# Step 4: "production" target #
+###############################
+
+FROM build as production
+ENV NODE_ENV=production
+# Copy the transpiled code to use in production (in /app)
+COPY --from=build /app/dist ./dist
+COPY package.json package-lock.json ./
+# Install production dependencies and clean cache
+RUN npm install --production && \
+    npm cache clean --force
+# Install pm2
+RUN npm install pm2 -g
+# Copy the pm2 config
+COPY ecosystem.config.js .
+
+CMD [ "pm2-runtime", "start", "ecosystem.config.js" ]

--- a/server/babel.config.js
+++ b/server/babel.config.js
@@ -6,6 +6,7 @@ module.exports = {
         targets: {
           node: process.versions.node
         },
+        useBuiltIns: "entry",
       },
     ],
   ],

--- a/server/docker-compose.dev.db.yml
+++ b/server/docker-compose.dev.db.yml
@@ -3,6 +3,6 @@ services:
   db:
     image: mongo:latest
     volumes:
-      - ./mongo-dev/db:/data/db
+      - ../mongo-dev/db:/data/db
     ports:
-      - "${WEB_PORT:-27017}:27017"
+      - "${DB_PORT:-27017}:27017"

--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -1,4 +1,4 @@
-# production mode
+# development mode
 version: '3.4'
 services:
   db:
@@ -7,18 +7,27 @@ services:
       - "27017"
     networks:
       - candilib-network
-    container_name: candilib_mongo
     volumes:
-      - ${DBDATA:-../mongo}:/data/db
+      - mongodata:/data/db
   api:
     image: candilib_api:${APP_VERSION:-latest}
     build:
+      target: development
       context: ./
       dockerfile: Dockerfile
       args:
         proxy: ${http_proxy}
         no_proxy: ${no_proxy}
         npm_registry: ${NPM_REGISTRY}
+    volumes:
+      - .:/app:delegated
+      - ./package.json:/package.json
+      - ./package-lock.json:/package-lock.json
+      # this is a workaround to prevent host node_modules from accidently getting mounted in container
+      # in case you want to use node/npm both outside container for test/lint etc. and also inside container
+      # this will overwrite the default node_modules dir in container so it won't conflict with our
+      # /opt/node_modules location. Thanks to PR from @brnluiz
+      - notused:/app/node_modules
     container_name: candilib_api
     depends_on:
       - db
@@ -36,3 +45,6 @@ networks:
     driver: bridge
     driver_opts:
       com.docker.network.driver.mtu: 1450
+volumes:
+  notused:
+  mongodata:

--- a/server/package.json
+++ b/server/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "babel src -d dist",
+    "prebuild": "npm run lint",
     "dev": "nodemon --inspect --watch src boot-dev.js",
     "format": "prettier-eslint --write 'src/**/*.js'",
     "lint:only": "eslint src",

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -8,8 +8,8 @@ const PORT = process.env.PORT || 8000
 
 connect()
   .then(() => {
-    http.createServer(app).listen(PORT, 'localhost')
-    logger.info(`Server running at http://localhost:${PORT}/`)
+    http.createServer(app).listen(PORT, '0.0.0.0')
+    logger.info(`Server running at http://0.0.0.0:${PORT}/`)
   })
   .catch(error => {
     logger.error(`Server could not connect to DB, exiting`)

--- a/server/src/mongo-connection.js
+++ b/server/src/mongo-connection.js
@@ -5,7 +5,7 @@ import logger from './logger'
 
 const mongoURL = process.env.MONGO_URL || 'mongodb://localhost:27017/candilib'
 
-let mongoConnectionAttempt = 10
+let mongoConnectionAttempt = 30
 const delayBeforeAttempt = process.env.NODE_ENV === 'production' ? 2000 : 1000
 
 export const connect = async () => {


### PR DESCRIPTION
    Add first .travis: build, up, down  mongo and back container
    Add prebuild: lint
    Fix winston deps
    Use one Dockerfile for dev and prod with multistaging based on node:10-slim
    docker-compose.dev.db.yml: replace WEB_PORT with DB_PORT, move mongo-dev path to make docker happy
    docker-compose.prod.api.yml: Merge feat/api-pm2-config
    Add .gitignore mongo-dev
    App Listen on 0.0.0.0
    increase mongoConnectionAttempt to 30s