### PR TITLE
Add NPM_AUDIT_DRY_RUN variable to launch npm audit in dry run mode

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -84,6 +84,7 @@ dollar = $(shell echo \$$)
 NPM_REGISTRY  := $(shell echo $$NPM_REGISTRY )
 SASS_REGISTRY  := $(shell echo $$SASS_REGISTRY )
 CYPRESS_DOWNLOAD_MIRROR  := $(shell echo $$CYPRESS_DOWNLOAD_MIRROR )
+NPM_AUDIT_DRY_RUN  := $(shell echo $$NPM_AUDIT_DRY_RUN )
 
 # Run env
 #  Mongo DB volume path

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -60,6 +60,7 @@ COPY --from=build /app/dist ./dist
 COPY package.json package-lock.json ./
 # Install production dependencies and clean cache
 RUN npm install --production && \
+    npm config set audit-level moderate && \
     npm audit --json --registry=https://registry.npmjs.org || ${NPM_AUDIT_DRY_RUN:-false} && \
     npm cache clean --force
 

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -53,13 +53,14 @@ RUN set -x ; npm run format && npm run test && npm run build:${CLIENT_BUILD_TARG
 ###############################
 
 FROM build as production
+ARG NPM_AUDIT_DRY_RUN
 ENV NODE_ENV=production
 # Copy the transpiled code to use in production (in /app)
 COPY --from=build /app/dist ./dist
 COPY package.json package-lock.json ./
 # Install production dependencies and clean cache
 RUN npm install --production && \
-    npm audit --json --registry=https://registry.npmjs.org && \
+    npm audit --json --registry=https://registry.npmjs.org || ${NPM_AUDIT_DRY_RUN:-false} && \
     npm cache clean --force
 
 # Deliver the dist folder with Nginx

--- a/client/docker-compose.prod.front.yml
+++ b/client/docker-compose.prod.front.yml
@@ -14,6 +14,7 @@ services:
         npm_registry: ${NPM_REGISTRY}
         sass_registry: ${SASS_REGISTRY}
         CYPRESS_DOWNLOAD_MIRROR: ${CYPRESS_DOWNLOAD_MIRROR}
+        NPM_AUDIT_DRY_RUN: ${NPM_AUDIT_DRY_RUN}
         CLIENT_BUILD_TARGET: candidat
 #    env_file:
 #      - ${cnf:-.env}
@@ -38,6 +39,7 @@ services:
         npm_registry: ${NPM_REGISTRY}
         sass_registry: ${SASS_REGISTRY}
         CYPRESS_DOWNLOAD_MIRROR: ${CYPRESS_DOWNLOAD_MIRROR}
+        NPM_AUDIT_DRY_RUN: ${NPM_AUDIT_DRY_RUN}
         CLIENT_BUILD_TARGET: admin
 #    env_file:
 #      - ${cnf:-.env}

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,8 @@
 # Step 1: Base target #
 #######################
 FROM node:10-slim as base
-ARG proxy
+ARG http_proxy
+ARG https_proxy
 ARG npm_registry
 ARG no_proxy
 
@@ -13,10 +14,10 @@ EXPOSE 8000
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo "Europe/Paris" > /etc/timezone
 # use proxy & private npm registry
-RUN if [ ! -z "$proxy" ] ; then \
+RUN if [ ! -z "$http_proxy" ] ; then \
         npm config delete proxy; \
-        npm config set proxy $proxy; \
-        npm config set https-proxy $proxy ; \
+        npm config set proxy $http_proxy; \
+        npm config set https-proxy $https_proxy ; \
         npm config set no-proxy $no_proxy; \
    fi ; \
    [ -z "$npm_registry" ] || npm config set registry=$npm_registry
@@ -46,13 +47,14 @@ RUN npm run build
 ###############################
 
 FROM build as production
+ARG NPM_AUDIT_DRY_RUN
 ENV NODE_ENV=production
 # Copy the transpiled code to use in production (in /app)
 COPY --from=build /app/dist ./dist
 COPY package.json package-lock.json ./
 # Install production dependencies and clean cache
 RUN npm install --production && \
-    npm audit --json --registry=https://registry.npmjs.org && \
+    npm audit --json --registry=https://registry.npmjs.org || ${NPM_AUDIT_DRY_RUN:-false} && \
     npm cache clean --force
 # Install pm2
 RUN npm install pm2 -g

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -54,6 +54,7 @@ COPY --from=build /app/dist ./dist
 COPY package.json package-lock.json ./
 # Install production dependencies and clean cache
 RUN npm install --production && \
+    npm config set audit-level moderate && \
     npm audit --json --registry=https://registry.npmjs.org || ${NPM_AUDIT_DRY_RUN:-false} && \
     npm cache clean --force
 # Install pm2

--- a/server/docker-compose.prod.api.yml
+++ b/server/docker-compose.prod.api.yml
@@ -10,6 +10,7 @@ services:
         proxy: ${http_proxy}
         no_proxy: ${no_proxy}
         npm_registry: ${NPM_REGISTRY}
+        NPM_AUDIT_DRY_RUN: ${NPM_AUDIT_DRY_RUN}
     container_name: candilib_api
     ports:
       - "${API_PORT:-8000}:8000"


### PR DESCRIPTION
Add NPM_AUDIT_DRY_RUN variable to launch npm audit in dry run mode.
Default to "false" to be strict, set to "true" if dry run
