### PR TITLE
Rename PUBLIC_URL as BASE_URL

### DIFF
--- a/client/src/api/api-paths.js
+++ b/client/src/api/api-paths.js
@@ -4,7 +4,7 @@ const isBuildWithAll = NODE_ENV !== 'production' || ['ALL', undefined].includes(
 const isBuildWithCandidat = NODE_ENV !== 'production' || ['ALL', 'CANDIDAT'].includes(CLIENT_BUILD_TARGET)
 const isBuildWithAdmin = NODE_ENV !== 'production' || ['ALL', 'ADMIN'].includes(CLIENT_BUILD_TARGET)
 
-const apiPrefix = `${process.env.BASE_URL || ''}/api/v2`
+const apiPrefix = `${process.env.BASE_URL || '/'}api/v2`
 
 // TODO: Use prepack to avoid presence of admin API paths for candidat build
 

--- a/client/src/api/api-paths.js
+++ b/client/src/api/api-paths.js
@@ -4,7 +4,7 @@ const isBuildWithAll = NODE_ENV !== 'production' || ['ALL', undefined].includes(
 const isBuildWithCandidat = NODE_ENV !== 'production' || ['ALL', 'CANDIDAT'].includes(CLIENT_BUILD_TARGET)
 const isBuildWithAdmin = NODE_ENV !== 'production' || ['ALL', 'ADMIN'].includes(CLIENT_BUILD_TARGET)
 
-const apiPrefix = `${process.env.PUBLIC_URL || ''}/api/v2`
+const apiPrefix = `${process.env.BASE_URL || ''}/api/v2`
 
 // TODO: Use prepack to avoid presence of admin API paths for candidat build
 

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -6,7 +6,10 @@ module.exports = {
 
   devServer: {
     proxy: {
-      '/api': {
+      '/candilib/api': {
+        pathRewrite: {
+          '/candilib': '',
+        },
         target: VUE_APP_URL_API || 'http://localhost:8000',
       },
     },


### PR DESCRIPTION
Client: remplace PUBLIC_URL par BASE_URL pour forcer /candilib/api/v2