### PR TITLE
Permettre au candidat de mettre une adresse libre #204

### DIFF
--- a/client/src/views/candidat/components/SignupForm.vue
+++ b/client/src/views/candidat/components/SignupForm.vue
@@ -345,13 +345,15 @@ export default {
 
     async fetchMatchingAdresses (val) {
       this.isFetchingMatchingAdresses = true
+      this.adresses[Math.min(this.adresses.length - 1, 0)] = val
       try {
         const adresses = await getAdresses(val)
         this.adresses = (adresses.features && adresses.features.length)
           ? adresses.features
             .filter(adr => adr.properties.type.includes('housenumber'))
             .map(feature => feature.properties.label)
-          : []
+            .concat([val])
+          : this.adresses
       } catch (error) {
       }
       this.isFetchingMatchingAdresses = false

--- a/client/src/views/candidat/components/selection-summary/MyReservation.vue
+++ b/client/src/views/candidat/components/selection-summary/MyReservation.vue
@@ -224,9 +224,6 @@ export default {
     text-transform: uppercase;
   }
 
-  .confirm-suppr-text-content {
-  }
-
   .va-b {
     vertical-align: baseline;
   }


### PR DESCRIPTION
fixes #204 

Désormais, la saisie du candidat du champ adresse fait partie des choix proposés. Utile si son adresse n'est pas répertoriée par l'API officielle.