### PR TITLE
Make email addresses case insensitive

### DIFF
--- a/server/src/models/candidat/candidat.model.js
+++ b/server/src/models/candidat/candidat.model.js
@@ -125,6 +125,8 @@ CandidatSchema.pre('save', async function preSave () {
     }
   })
 
+  candidat.email = candidat.email.toLowerCase()
+
   candidat.prenom =
     candidat.prenom &&
     candidat.prenom.normalize('NFD').replace(/[\u0300-\u036f]/g, '')

--- a/server/src/models/whitelisted/whitelisted.model.js
+++ b/server/src/models/whitelisted/whitelisted.model.js
@@ -17,7 +17,7 @@ const WhitelistedSchema = new Schema({
 
 WhitelistedSchema.pre('save', async function preSave () {
   const whitelisted = this
-  whitelisted.email = sanitizeHtml(whitelisted.email)
+  whitelisted.email = sanitizeHtml(whitelisted.email.toLowerCase())
 })
 
 export default mongoose.model('Whitelisted', WhitelistedSchema, 'whitelisted')

--- a/server/src/routes/admin/whitelisted.controllers.js
+++ b/server/src/routes/admin/whitelisted.controllers.js
@@ -8,10 +8,17 @@ import {
 } from '../../models/whitelisted'
 
 export const isWhitelisted = async (req, res, next) => {
-  const { email } = req.body
+  const email = req.body && req.body.email
+  if (!email) {
+    return res.status(401).send({
+      codemessage: 'ERROR_FIELDS_EMPTY',
+      message: messages.ERROR_FIELDS_EMPTY,
+      success: false,
+    })
+  }
 
   try {
-    const candidat = await findWhitelistedByEmail(email)
+    const candidat = await findWhitelistedByEmail(email.toLowerCase())
     if (candidat === null) {
       return res.status(401).send({
         codemessage: 'NO_AUTH_WHITELIST',

--- a/server/src/routes/admin/whitelisted.controllers.spec.js
+++ b/server/src/routes/admin/whitelisted.controllers.spec.js
@@ -1,0 +1,55 @@
+import request from 'supertest'
+import express from 'express'
+import bodyParser from 'body-parser'
+
+import { connect, disconnect } from '../../mongo-connection'
+
+import { isWhitelisted } from './whitelisted.controllers'
+import { createWhitelisted } from '../../models/whitelisted'
+
+const app = express()
+app.use(bodyParser.json({ limit: '20mb' }))
+app.use(bodyParser.urlencoded({ limit: '20mb', extended: false }))
+app.use(isWhitelisted)
+app.use((req, res) => res.json({}))
+
+describe('Test get and export candidats', () => {
+  beforeAll(async () => {
+    createWhitelisted('TEst@Gmail.cOm')
+    await connect()
+  })
+
+  afterAll(async () => {
+    await disconnect()
+  })
+
+  it('Should call next middleware', async () => {
+    await request(app)
+      .post(``)
+      .send({
+        email: 'test@gmail.com',
+      })
+      .set('Accept', 'application/json')
+      .expect(200)
+  })
+
+  it('Should call next middleware', async () => {
+    await request(app)
+      .post(``)
+      .send({
+        email: 'test@gMail.com',
+      })
+      .set('Accept', 'application/json')
+      .expect(200)
+  })
+
+  it('Should call next middleware', async () => {
+    await request(app)
+      .post(``)
+      .send({
+        email: 'TEST@GMAIL.COM',
+      })
+      .set('Accept', 'application/json')
+      .expect(200)
+  })
+})


### PR DESCRIPTION
- This is to avoid calls from candidates that enter email addresses
  with a different case than the one saved in the whitelist

fixes #143 