### PR TITLE
:sparkles: Configure morgan to log in json

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -3,7 +3,7 @@ import morgan from 'morgan'
 import bodyParser from 'body-parser'
 import fileupload from 'express-fileupload'
 
-import { loggerStream } from './util/logger'
+import { loggerStream, jsonFormat } from './util/logger'
 import routes from './routes'
 
 import npmVersion from '../package.json'
@@ -16,10 +16,7 @@ app.get(`${apiPrefix}/version`, function (req, res) {
   res.send(npmVersion.version)
 })
 
-const formatAsNginx =
-  ':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" :response-time'
-
-app.use(morgan(formatAsNginx, { stream: loggerStream }))
+app.use(morgan(jsonFormat, { stream: loggerStream }))
 app.use(bodyParser.json({ limit: '20mb' }))
 app.use(bodyParser.urlencoded({ limit: '20mb', extended: false }))
 app.use(fileupload({ limits: { fileSize: 50 * 1024 * 1024 } }))

--- a/server/src/util/logger.js
+++ b/server/src/util/logger.js
@@ -32,6 +32,38 @@ const logFormat = printf(({ level, message }) => `${level} ${message}`)
 
 const simplestFormat = printf(({ message }) => message)
 
+export const formatAsNginx =
+  ':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" :response-time'
+
+export function jsonFormat(tokens, req, res) {
+  return JSON.stringify({
+    api: {
+      'time_local': tokens.date(req, res, 'iso'),
+      'method': tokens.method(req, res),
+      'request_uri': tokens.url(req, res),
+      'uri': tokens.url(req, res),
+      'status': tokens.status(req, res),
+      'content_length': tokens.res(req, res, 'content-length'),
+      'http_referrer': tokens.referrer(req, res),
+      'http_version': tokens['http-version'](req, res),
+      'remote_addr': tokens['remote-addr'](req, res),
+      'remote_user': tokens['remote-user'](req, res),
+      'http_user_agent': tokens['user-agent'](req, res),
+      'response_time': tokens['response-time'](req, res),
+    }
+  });
+}
+
+export const getRequestLogAsJson = (tokens, req, res) => {
+  return [
+    tokens.method(req, res),
+    tokens.url(req, res),
+    tokens.status(req, res),
+    tokens.res(req, res, 'content-length'), '-',
+    tokens['response-time'](req, res), 'ms'
+  ].join(' ')
+}
+
 export const simpleLogger = createLogger({
   format: logFormat,
   transports: [new transports.Console(options.console)],
@@ -54,6 +86,16 @@ export const techLogger = createLogger({
   exitOnError: false,
 })
 
+export const morganLogger = createLogger({
+  format: combine(
+    label({ label: TECH_LABEL }),
+    timestamp(),
+    simplestFormat,
+  ),
+  transports: [new transports.Console(options.console)],
+  exitOnError: false,
+})
+
 export const appLogger = createLogger({
   format: combine(
     label({ label: APP_LABEL }),
@@ -66,6 +108,6 @@ export const appLogger = createLogger({
 
 export const loggerStream = {
   write (message, encoding) {
-    simplestLogger.info(message)
+    (isProd ? morganLogger : simplestLogger).info(message)
   },
 }


### PR DESCRIPTION
Cette modification permet d'avoir ce type de ligne de log lors d'une requête :

```json
{
    "api": {
        "time_local": "2019-06-05T11:54:18.215Z",
        "method": "GET",
        "request_uri": "/api/v2/candidat/places/5cf63145b2a7cffde20e98b7?begin=2019-06-05T13%3A54%3A18.165%2B02%3A00&end=2019-09-30T23%3A59%3A59.999%2B02%3A00",
        "uri": "/api/v2/candidat/places/5cf63145b2a7cffde20e98b7?begin=2019-06-05T13%3A54%3A18.165%2B02%3A00&end=2019-09-30T23%3A59%3A59.999%2B02%3A00",
        "status": "200",
        "content_length": "1025",
        "http_referrer": "http://localhost:8080/candilib/candidat/93/Villepinte/lundi%2008%20juillet%202019/false/selection-place",
        "http_version": "1.1",
        "remote_addr": "127.0.0.1",
        "http_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:68.0) Gecko/20100101 Firefox/68.0",
        "response_time": "35.194"
    }
}```