### PR TITLE
fix/security-nginx

### DIFF
--- a/client/nginx/nginx.template
+++ b/client/nginx/nginx.template
@@ -14,6 +14,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    server_tokens off;
     add_header X-Frame-Options SAMEORIGIN;
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";


### PR DESCRIPTION
* don't send the nginx version number in error pages and Server header