### PR TITLE
Modify admin mail cancelation

### DIFF
--- a/server/src/routes/business/mail/cancel-booking-by-admin-template.js
+++ b/server/src/routes/business/mail/cancel-booking-by-admin-template.js
@@ -10,8 +10,8 @@ export const getCancelBookingByAdminTemplate = (
 <br>
 <p>
   Votre réservation à ${nameCentre} le ${dateResa} à ${houreResa} avec le numéro NEPH ${codeNeph} a été annulée suite à un imprévu lié à l'administration.
-  Vous serez contacté dans les prochains jours pour replanifier un créneau à votre convenance.
-  Vous pouvez aussi solliciter <a href=${urlFAQ}>le service administratif dédié</a> dès à présent.
+  Vous pouvez dès à présent replanifier un créneau à votre convenance : <a href=${urlRESA}>se connecter</a>
+  Veuillez nous excuser pour la gène occasionnée.
 </p>
 <br>
 <p align="right">L'équipe Candilib</p>`


### PR DESCRIPTION
Mise à jour du mail d'annulation par l'administration pour inviter à choisir une nouvelle date au lieu d'appeler la répartition.