### PR TITLE
Build & deploy dev environment on netlify/heroku

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,7 +188,11 @@ server/mongo-dev/
 mongo-dev
 
 VERSION
-candilib-*-build/
+candilibV2-*-build/
+candilibV2-*-dist/
 
 test-db
 mongo
+
+# Local Netlify folder
+.netlify

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
+os: linux
 dist: trusty
-sudo: required
 
-language: minimal
+language: shell
 
 services:
   - docker
@@ -27,10 +27,27 @@ before_script:
   - uname -a
   - type -a docker-compose && docker-compose version
   - docker version
-
 script:
   - ( git fetch --unshallow || true ) && git tag -l
   - ci/run-tests.sh
+
+deploy:
+  - provider: script
+    script: bash ci/deploy.sh test $TRAVIS_BRANCH
+    cleanup: true
+    on:
+      branch: devops/*
+  - provider: script
+    script: bash ci/deploy.sh qualif $TRAVIS_BRANCH
+    cleanup: true
+    on:
+      branch: qualif/*
+  - provider: script
+    script: bash ci/deploy.sh develop $TRAVIS_BRANCH
+    cleanup: true
+    on:
+      branch: develop
+
 after_script:
   - make clean-images clean-dir
   - echo "END"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,17 +33,17 @@ script:
 
 deploy:
   - provider: script
-    script: bash ci/deploy.sh test $TRAVIS_BRANCH
+    script: ci/deploy.sh test $TRAVIS_BRANCH
     cleanup: true
     on:
       branch: devops/*
   - provider: script
-    script: bash ci/deploy.sh qualif $TRAVIS_BRANCH
+    script: ci/deploy.sh qualif $TRAVIS_BRANCH
     cleanup: true
     on:
       branch: qualif/*
   - provider: script
-    script: bash ci/deploy.sh develop $TRAVIS_BRANCH
+    script: ci/deploy.sh develop $TRAVIS_BRANCH
     cleanup: true
     on:
       branch: develop

--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,26 @@ init-db-e2e:
 #
 clean-log-e2e:
 	rm e2e.log
+
+#
+# Extract files from candidat/admin docker images
+#
+export-front-all: build-dir build-dist-dir export-front-candidat export-front-admin extract-export-front-candidat extract-export-front-admin
+build-dist-dir:
+	mkdir -p $(DIST_DIR)/dist/{candilib-repartiteur,candilib}
+clean-dist-dir:
+	if [ -d "$(DIST_DIR)" ] ; then rm -rf $(DIST_DIR) ; fi
+export-front-candidat: check-up-front-candidat network-up
+#	${DC} -f ${DC_APP_FRONT_CANDIDAT_RUN_PROD} run -T --no-deps --rm front_candidat /bin/bash -c "(cd /usr/share/nginx/html && find . -type f)"
+	${DC} -f ${DC_APP_FRONT_CANDIDAT_RUN_PROD} run -T --no-deps --rm front_candidat /bin/bash -c "( cd /usr/share/nginx/html && tar zCcf ./ - . )"  > $(BUILD_DIR)/$(FILE_FRONT_CANDIDAT_APP_VERSION)
+export-front-admin: check-up-front-admin network-up
+	${DC} -f ${DC_APP_FRONT_ADMIN_RUN_PROD} run -T --no-deps --rm front_admin /bin/bash -c "( cd /usr/share/nginx/html && tar zCcf ./ - . )"  > $(BUILD_DIR)/$(FILE_FRONT_ADMIN_APP_VERSION)
+extract-export-front-candidat:
+	( cd $(DIST_DIR)/dist/candilib && tar -zxvf $(BUILD_DIR)/$(FILE_FRONT_CANDIDAT_APP_VERSION) )
+extract-export-front-admin:
+	( cd $(DIST_DIR)/dist/candilib-repartiteur && tar -zxvf $(BUILD_DIR)/$(FILE_FRONT_ADMIN_APP_VERSION) )
+
+
 #
 # save images
 #

--- a/Makefile.mk
+++ b/Makefile.mk
@@ -11,6 +11,7 @@ APP_DB_PATH    := $(APP_PATH)/server
 
 BUILD_DIR     := ${APP_PATH}/${APP}-${APP_VERSION}-build
 ARCHIVE_DIR   := ${APP_PATH}/${APP}-${APP_VERSION}
+DIST_DIR      := ${APP_PATH}/${APP}-${APP_VERSION}-dist
 
 # binaries
 DOCKER   := $(shell type -p docker)
@@ -60,6 +61,9 @@ DC_APP_E2E_RUN_PROD              := $(APP_FRONT_PATH)/docker-compose.e2e.yml
 FILE_ARCHIVE_APP_VERSION = $(APP)-$(APP_VERSION)-archive.tar.gz
 FILE_ARCHIVE_LATEST_VERSION = $(APP)-$(LATEST_VERSION)-archive.tar.gz
  
+FILE_FRONT_CANDIDAT_APP_VERSION = $(APP)-front-candidat-$(APP_VERSION)-archive.tar.gz
+FILE_FRONT_ADMIN_APP_VERSION = $(APP)-front-admin-$(APP_VERSION)-archive.tar.gz
+
 # docker image name save
 FILE_IMAGE_FRONT_CANDIDAT_APP_VERSION = $(APP)-front-candidat-$(APP_VERSION)-image.tar.gz
 FILE_IMAGE_FRONT_CANDIDAT_LATEST_VERSION = $(APP)-front-candidat-$(LATEST_VERSION)-image.tar.gz

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+set -ex
+echo "Deploy $0 $@"
+DEPLOY_ENV="$1"
+BRANCH="$2"
+
+# env config
+# DISABLE_DEPLOY=true # disable this script and exit 0
+# DISABLE_DEPLOY_HEROKU=true # skip heroku deployment
+# DISABLE_DEPLOY_NETLIFY=true # skip netlify deployment
+# HEROKU_EMAIL
+# HEROKU_TOKEN
+# HEROKU_APP_TEST
+# HEROKU_APP_QUALIF
+# HEROKU_APP_DEV
+# NETLIFY_AUTH_TOKEN
+# NETLIFY_SITE based on HEROKU_APP.netlify.com
+
+if [ -n "$DISABLE_DEPLOY" -a "$DISABLE_DEPLOY" == "true" ]; then
+  echo "Disable deploy"
+  exit 0
+fi
+
+# for each ENV get heroku target app
+case "$DEPLOY_ENV" in
+  test)    HEROKU_APP=$HEROKU_APP_TEST ;;
+  qualif)  HEROKU_APP=$HEROKU_APP_QUALIF ;;
+  develop) HEROKU_APP=$HEROKU_APP_DEV ;;
+  *)       HEROKU_APP="" ;;
+esac
+
+if [ -z "$HEROKU_APP" ] ;then
+  echo "ERROR: empty HEROKU_APP for ${DEPLOY_ENV}"
+  echo "No deployment target available"
+  exit 1
+fi
+
+#
+# Deploy API on heroku
+#
+if [ -n "${DISABLE_DEPLOY_HEROKU}" -a "${DISABLE_DEPLOY_HEROKU}" == "true" ]; then
+  echo "Disable heroku deploy"
+else
+echo "# Deploy API"
+if [ -z "$HEROKU_EMAIL" -o -z "$HEROKU_TOKEN" ]; then
+  echo "ERROR: empty variable HEROKU_EMAIL, HEROKU_TOKEN and HEROKU_APP"
+  echo "No deployment"
+  exit 1
+fi
+
+# install heroku cli
+sudo apt-get update -qqy
+sudo apt-get install -qqy curl git gnupg
+curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
+heroku version
+docker images
+
+# configure heroku cli
+cat >~/.netrc <<EOF
+machine api.heroku.com
+  login $HEROKU_EMAIL
+  password $HEROKU_TOKEN
+machine git.heroku.com
+  login $HEROKU_EMAIL
+  password $HEROKU_TOKEN
+EOF
+chmod 600 ~/.netrc
+
+## deploy app using remote git
+# git checkout -b netlify
+# heroku git:remote --app $HEROKU_APP
+# git push heroku netlify:master -f
+
+## or deploy app using docker registry
+echo "$(heroku auth:token)" | docker login --username=_ --password-stdin registry.heroku.com
+APP_VERSION="$(./ci/version.sh)"
+docker tag candilib_api:$APP_VERSION registry.heroku.com/$HEROKU_APP/web
+docker push registry.heroku.com/$HEROKU_APP/web
+heroku container:release web --app $HEROKU_APP
+# first time : setup DB
+BRANCH_DIR=$(echo $BRANCH |tr '/' '-')
+heroku run --no-tty -a $HEROKU_APP "( cd /app && wget  -L https://github.com/LAB-MI/candilibV2/archive/${BRANCH}.tar.gz -O - |tar zxvf - --strip-components=2 candilibV2-${BRANCH_DIR}/server/dev-setup ) && npm run dev-setup"
+# TODO: variable REPO
+
+rm -rf ~/.netrc
+fi
+
+#
+# Deploy FRONT on netlify
+#
+if [ -n "${DISABLE_DEPLOY_NETLIFY}" -a "${DISABLE_DEPLOY_NETLIFY}" == "true" ]; then
+  echo "Disable netlify deploy"
+else
+
+echo "# Deploy front"
+export NETLIFY_SITE_ID=$HEROKU_APP.netlify.com
+
+if [ -z "$NETLIFY_AUTH_TOKEN" -o -z "$NETLIFY_SITE_ID" ]; then
+  echo "ERROR: empty variable NETLIFY_AUTH_TOKEN, NETLIFY_SITE_ID"
+  echo "No deployment"
+  exit 1
+fi
+
+# Install netlify-cli
+curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+sudo apt-get install -y nodejs
+npm --version
+sudo npm install -g netlify-cli
+
+# Extract front files from previously docker images
+make export-front-all
+APP_VERSION="$(./ci/version.sh)"
+
+cd candilibV2-$APP_VERSION-dist
+
+# Generate route files (/api -> http://API/)
+cat > dist/_redirects <<EOF
+/candilib/api/* https://$HEROKU_APP.herokuapp.com/api/:splat 200
+/candilib-repartiteur/api/* https://$HEROKU_APP.herokuapp.com/api/:splat 200
+/candilib/* /candilib/index.html 200
+/candilib-repartiteur/* /candilib-repartiteur/index.html 200
+EOF
+# Generate simple index for testing site
+cat > dist/index.html <<EOF
+<H1>CandilibV2 $APP_VERSION</H1>
+<ul>
+  <li><a href="/candilib">Candidat</a></li>
+  <li><a href="/candilib-repartiteur">Admin</a></li>
+</ul>
+EOF
+
+# deploy files
+netlify deploy --prod --dir=dist --message "Deploy $APP_VERSION" --json | tee -a netlify.json
+
+deploy_id="$(cat netlify.json |jq -re '.deploy_id')"
+
+curl_args="--fail --retry 10 --retry-delay 5 --retry-max-time 60 --connect-timeout 10 "
+# lock deployment
+curl ${curl_args} -o /dev/null -X POST -H "Content-Type: application/json" \
+  -d '{}' \
+  https://api.netlify.com/api/v1/deploys/${deploy_id}/lock?access_token=${NETLIFY_AUTH_TOKEN} \
+  || exit $?
+echo "lock: $?"
+
+# publish file
+curl ${curl_args} -o /dev/null -X POST -H "Content-Type: application/json" \
+  -d '{}' \
+  https://api.netlify.com/api/v1/deploys/${deploy_id}/restore?access_token=${NETLIFY_AUTH_TOKEN} \
+  || exit $?
+echo "Publish: $?"
+
+fi
+
+exit 0

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,22 +1,68 @@
 #!/bin/bash
 set -ex
-echo "Deploy $0 $@"
-DEPLOY_ENV="$1"
-BRANCH="$2"
 
-# env config
+# env config (can be overrided in travis Environment Variables)
 # DISABLE_DEPLOY=true # disable this script and exit 0
 # DISABLE_DEPLOY_HEROKU=true # skip heroku deployment
 # DISABLE_DEPLOY_NETLIFY=true # skip netlify deployment
+# DISABLE_SLACK_NOTIFICATION=true # disable slack notification
 # HEROKU_EMAIL
 # HEROKU_TOKEN
 # HEROKU_APP_TEST
 # HEROKU_APP_QUALIF
 # HEROKU_APP_DEV
 # NETLIFY_AUTH_TOKEN
-# NETLIFY_SITE based on HEROKU_APP.netlify.com
+# NETLIFY_SITE_ID is based on HEROKU_APP.netlify.com
+
+function clean {
+  ret=$?
+  if [ "$ret" -gt 0 ]; then
+    echo "ERROR: $0 $ret"
+    slack_post_failure
+  else
+    echo "SUCCESS: $0 $ret"
+    slack_post_success
+  fi
+  exit $ret
+}
+
+function slack_post_failure {
+  if [ -n "$DISABLE_SLACK_NOTIFICATION" ] && [ "$DISABLE_SLACK_NOTIFICATION" == "true" ]; then
+    echo "Disable slack notification"
+  else
+    (
+    SHORT_COMMIT=$(echo "$TRAVIS_COMMIT" |cut -c 1-7)
+    cat <<EOF | ci/slackpost.sh "$SLACK_WEBHOOK" "$SLACK_CHANNEL" "Travis CI" ERROR
+Deploy <$TRAVIS_BUILD_WEB_URL|#$TRAVIS_BUILD_NUMBER> (<https://github.com/$TRAVIS_REPO_SLUG/commit/$TRAVIS_COMMIT|$SHORT_COMMIT>) on $TRAVIS_BRANCH failed !
+EOF
+    ) || true
+  fi
+}
+
+function slack_post_success {
+  if [ -n "$DISABLE_SLACK_NOTIFICATION" ] && [ "$DISABLE_SLACK_NOTIFICATION" == "true" ]; then
+    echo "Disable slack notification"
+  else
+    (
+    SHORT_COMMIT=$(echo "$TRAVIS_COMMIT" |cut -c 1-7)
+    cat <<EOF | ci/slackpost.sh "$SLACK_WEBHOOK" "$SLACK_CHANNEL" "Travis CI" INFO
+Deploy <$TRAVIS_BUILD_WEB_URL|#$TRAVIS_BUILD_NUMBER> (<https://github.com/$TRAVIS_REPO_SLUG/commit/$TRAVIS_COMMIT|$SHORT_COMMIT>) on $TRAVIS_BRANCH passed.
+:arrow_right: You can connect to the <https://$NETLIFY_SITE_ID|$DEPLOY_ENV environment> !
+EOF
+    ) || true
+  fi
+}
+
+# trap exit code and call clean function
+trap clean EXIT QUIT
+
+#
+echo "Deploy $0 $*"
+DEPLOY_ENV="$1"
+BRANCH="$2"
 
 if [ -n "$DISABLE_DEPLOY" -a "$DISABLE_DEPLOY" == "true" ]; then
+  DISABLE_SLACK_NOTIFICATION=true
   echo "Disable deploy"
   exit 0
 fi
@@ -34,6 +80,8 @@ if [ -z "$HEROKU_APP" ] ;then
   echo "No deployment target available"
   exit 1
 fi
+
+export NETLIFY_SITE_ID=$HEROKU_APP.netlify.com
 
 #
 # Deploy API on heroku
@@ -93,7 +141,6 @@ if [ -n "${DISABLE_DEPLOY_NETLIFY}" -a "${DISABLE_DEPLOY_NETLIFY}" == "true" ]; 
 else
 
 echo "# Deploy front"
-export NETLIFY_SITE_ID=$HEROKU_APP.netlify.com
 
 if [ -z "$NETLIFY_AUTH_TOKEN" -o -z "$NETLIFY_SITE_ID" ]; then
   echo "ERROR: empty variable NETLIFY_AUTH_TOKEN, NETLIFY_SITE_ID"
@@ -111,6 +158,7 @@ sudo npm install -g netlify-cli
 make export-front-all
 APP_VERSION="$(./ci/version.sh)"
 
+(
 cd candilibV2-$APP_VERSION-dist
 
 # Generate route files (/api -> http://API/)
@@ -148,6 +196,7 @@ curl ${curl_args} -o /dev/null -X POST -H "Content-Type: application/json" \
   https://api.netlify.com/api/v1/deploys/${deploy_id}/restore?access_token=${NETLIFY_AUTH_TOKEN} \
   || exit $?
 echo "Publish: $?"
+)
 
 fi
 

--- a/ci/run-tests.sh
+++ b/ci/run-tests.sh
@@ -2,7 +2,7 @@
 basename=$(basename $0)
 ret=1
 echo "# build all services (front_candidat,front_admin,api,db) in prod mode"
-time make build-all NPM_AUDIT_DRY_RUN=false
+time make build-all NPM_AUDIT_DRY_RUN=${NPM_AUDIT_DRY_RUN:-false}
 ret=$?
 if [ "$ret" -gt 0 ] ; then
   echo "$basename build-all ERROR"

--- a/ci/slackpost.sh
+++ b/ci/slackpost.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -x
+
+# Usage: slackpost "<webhook_url>" "<channel>" "<username>" "<level>" "<message>"
+# also (echo $RANDOM; echo $RANDOM) |slackpost "<channel>" "<username>"
+
+# ------------
+webhook_url=$1
+if [[ $webhook_url == "" ]]; then
+        echo "No webhook_url specified"
+        exit 1
+fi
+
+# ------------
+shift
+channel=$1
+if [[ $channel == "" ]]; then
+        echo "No channel specified"
+        exit 1
+fi
+
+# ------------
+shift
+username=$1
+if [[ $username == "" ]]; then
+        echo "No username specified"
+        exit 1
+fi
+
+# ------------
+shift
+level=$1
+if [[ $level == "" ]]; then
+        echo "No level specified"
+        exit 1
+fi
+
+case "$level" in
+  INFO)
+    SLACK_ICON=':white_check_mark:'
+    SLACK_COLOR='good'
+    ;;
+  WARNING)
+    SLACK_ICON=':warning:'
+    SLACK_COLOR='warning'
+    ;;
+  ERROR)
+    SLACK_ICON=':bangbang:'
+    SLACK_COLOR='danger'
+    ;;
+  *)
+    SLACK_ICON=':slack:'
+    SLACK_COLOR='grey'
+    ;;
+esac
+
+# ------------
+shift
+
+text=$*
+
+if [[ $text == "" ]]; then
+while IFS= read -r line; do
+  #printf '%s\n' "$line"
+  text="$text$line\n"
+done
+fi
+
+
+if [[ $text == "" ]]; then
+        echo "No text specified"
+        exit 1
+fi
+
+escapedText=$(echo "$text" | sed 's/"/\"/g' | sed "s/'/\'/g" )
+
+json="{\"channel\": \"$channel\", \"username\":\"$username\", \"attachments\":[{\"color\":\"$SLACK_COLOR\" , \"text\": \" $SLACK_ICON $escapedText\"}]}"
+
+curl -s -d "payload=$json" "$webhook_url"

--- a/heroku.yml.sample
+++ b/heroku.yml.sample
@@ -1,0 +1,11 @@
+build:
+  docker:
+     release:
+        dockerfile: server/Dockerfile
+     web: server/Dockerfile
+  config:
+    NPM_AUDIT_DRY_RUN: true
+release:
+  image: web
+  command:
+    - ( cd /app && wget  -L https://github.com/LAB-MI/candilibV2/archive/develop.tar.gz -O - |tar zxvf - --strip-components=2 candilibV2-develop/server/dev-setup ) && npm run dev-setup

--- a/netlify.toml.sample
+++ b/netlify.toml.sample
@@ -1,0 +1,7 @@
+[build]
+  base = "client/"
+  command = "( APP_VERSION=$(../ci/version.sh) ;  npm --no-git-tag-version version ${APP_VERSION} ; npm install && npm run format && npm run test && npm run build && npm install --production ) ; mv dist dst; mkdir dist/; mv dst dist/candilib ; echo -e \"/candilib/api/*   $API_URL/:splat   200\n/*   /candilib/index.html   200\" > dist/_redirects ; cat dist/_redirects"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "12.3.1"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,9 +12,9 @@ WORKDIR /app
 # Expose the listening port of your app
 EXPOSE 8000
 
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo "Europe/Paris" > /etc/timezone
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo "Europe/Paris" > /etc/timezone ; \
 # use proxy & private npm registry
-RUN if [ ! -z "$http_proxy" ] ; then \
+    if [ ! -z "$http_proxy" ] ; then \
         npm config delete proxy; \
         npm config set proxy $http_proxy; \
         npm config set https-proxy $https_proxy; \
@@ -52,18 +52,17 @@ FROM build as production
 ARG NPM_AUDIT_DRY_RUN
 ENV NODE_ENV=production
 ARG APP_VERSION
+COPY package.json package-lock.json ./
+# Copy the pm2 config
+COPY ecosystem.config.js .
 # Copy the transpiled code to use in production (in /app)
 COPY --from=build /app/dist ./dist
-COPY package.json package-lock.json ./
 # Install production dependencies and clean cache
 RUN npm --no-git-tag-version version ${APP_VERSION} && \
     npm install --production && \
     npm config set audit-level moderate && \
     npm audit --json --registry=https://registry.npmjs.org || ${NPM_AUDIT_DRY_RUN:-false} && \
-    npm cache clean --force
-# Install pm2
-RUN npm install pm2 -g
-# Copy the pm2 config
-COPY ecosystem.config.js .
+    npm cache clean --force ; \
+    npm install pm2 -g
 
 CMD [ "pm2-runtime", "start", "ecosystem.config.js", "--env", "production" ]

--- a/server/docker-compose.prod.all.yml
+++ b/server/docker-compose.prod.all.yml
@@ -20,6 +20,7 @@ services:
   api:
     image: candilib_api:${APP_VERSION:-latest}
     build:
+      target: production
       context: ./
       dockerfile: Dockerfile
       args:

--- a/server/docker-compose.prod.api.yml
+++ b/server/docker-compose.prod.api.yml
@@ -5,6 +5,7 @@ services:
     image: candilib_api:${APP_VERSION:-latest}
     container_name: candilib_api
     build:
+      target: production
       context: ./
       dockerfile: Dockerfile
       args:

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -179,4 +179,8 @@ if (config.smtpUser) {
   }
 }
 
+if (config.smtpService) {
+  smtpOptions.service = config.smtpService
+}
+
 export default config


### PR DESCRIPTION
Find here, configuration files to deploy front/back in test/dev/qualif environment after successfull build.
* in travis, we launch "deploy" step  after successfull build:
  * deploy in test env only for devops/* branch
  * deploy in dev env only for develop/* branch
  * deploy in qualif env only for qualif/* branch
  * travis execute ci/deploy.sh to deploy/publish on heroku and netlify
  * to reduce time, we push and deploy the previously api docker image on heroku environment private registry, and execute "dev-setup" at bootstrap container
  * then we extract html/css files from both candidat and admin docker image and publish on netlify environment domain.
  * Send notification (failure or success) on slack at the end of deploy

Addons:
* in server/Dockerfile use less build layer
* in server/docker-compose* , restricted on production target only
* in server/src/config.js: add optional smtpService option in config.js to use external smtp service (like: gmail) as described in nodemailer
  
For information: add sample config file for
* netlify (netlify.toml.sample) config file to build client (front)
* heroku (heroku.yml.sample) config file to build server(api)