### PR TITLE
Fix swagger doc to comply with OpenAPI 3

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -15,20 +15,13 @@ import npmVersion from '../package.json'
 /**
  * @swagger
  *
- * tags: [
- *  {
- *    "name": "Authentification",
- *    "description": "Pour s'authentifier à l'application"
- *  },
- *  {
- *    "name": "Administrateur",
- *    "description": "Pour toutes les actions liées aux administrateurs"
- *  },
- *  {
- *    "name": "Candidat",
- *    "description": "Pour toutes les actions liées aux candidats"
- *  }
- * ]
+ * tags:
+ *   - name: Authentification
+ *     description: Pour s'authentifier à l'application
+ *   - name: Administrateur
+ *     description: Pour toutes les actions liées aux administrateurs
+ *   - name: Candidat
+ *     description: Pour toutes les actions liées aux candidats
  *
  * components:
  *   securitySchemes:
@@ -58,7 +51,10 @@ import npmVersion from '../package.json'
  *         - type
  *       properties:
  *         coordinates:
- *           type: Array
+ *           type: array
+ *           items:
+ *             type: number
+ *             description: latitude ou longitude
  *           example: [ 2.552847, 48.962099 ]
  *         type:
  *           type: string
@@ -79,15 +75,23 @@ import npmVersion from '../package.json'
  *         _id:
  *           type: string
  *           description: identifiant du centre
+ *           example: 5dce6ec901353671dead895e
  *         nom:
  *           type: string
  *           description: Nom du centre (de la ville du centre)
+ *           example: Noisy le Grand
  *         label:
  *           type: string
  *           description: Information complémentaire pour retrouver le point de rencontre du centre
+ *           example: Centre d'examen du permis de conduire de Noisy le Grand
+ *         adresse:
+ *           type: string
+ *           description: Adresse du centre
+ *           example: 5 boulevard de Champs Richardets 93160 Noisy le Grand
  *         departement:
  *           type: string
  *           description: Département du centre
+ *           example: 75
  *
  *     CandidatInfo:
  *       type: object
@@ -625,8 +629,6 @@ if (isDevelopment) {
  *   get:
  *     summary: Version exacte de l'API déployée (Disponible uniquement depuis l'URL répartiteur)
  *     description: Retourne la version exacte de l'API déployée
- *     produces:
- *       - application/json
  *     responses:
  *       200:
  *         description: Numéro de version détaillée de l'API déployée

--- a/server/src/routes/admin/index.js
+++ b/server/src/routes/admin/index.js
@@ -50,8 +50,6 @@ router.post(
  *     tags: ["Administrateur"]
  *     summary: Récupération de mes infos administrateur
  *     description: Après connexion, renvoie les infos de l'administrateur connecté (id dans le JWT envoyé en header)
- *     produces:
- *      - application/json
  *     security:
  *       - bearerAuth: []
  *
@@ -88,9 +86,6 @@ router.get('/me', getMe)
  *     tags: ["Administrateur"]
  *     summary: Récupération des infos candidat
  *     description: L'administrateur récupère les informations d'un ou plusieurs candidats
- *     produces:
- *      - application/json
- *      - text/csv
  *     security:
  *       - bearerAuth: []
  *     parameters:
@@ -99,21 +94,18 @@ router.get('/me', getMe)
  *         schema:
  *           type: number
  *           example: 93
- *         required: false
  *         description: Un département accessible par l'admin
  *       - in: query
  *         name: matching
  *         schema:
  *           type: string
  *           example: 'Dupont'
- *         required: false
  *         description: Une chaîne de caractères pour chercher un candidat
  *       - in: query
  *         name: format
  *         schema:
  *           type: string
  *           example: 'csv'
- *         required: false
  *         description:
  *           Si `csv`, exporte les candidats au format csv.
  *           Fonctionne correctement seulement si le champ `for` est rempli avec `aurige`
@@ -122,7 +114,6 @@ router.get('/me', getMe)
  *         schema:
  *           type: string
  *           example: 'aurige'
- *         required: false
  *         description:
  *           Si `aurige`, considère que l'action aura pour but la synchronisation avec aurige.
  *           Généralement utilisé dans le cas d'un export csv.
@@ -151,7 +142,7 @@ router.get('/me', getMe)
  *               }]
  *           text/csv:
  *             schema:
- *               type: text/csv
+ *               type: string
  *             example: |-
  *               Code NEPH;Nom de naissance;Nom d'usage;Prénom;email
  *               093496239512;SWAISEY;SWAISEY;MAY;mayswaisey@candilib.com
@@ -166,8 +157,6 @@ router.get('/me', getMe)
  *     tags: ["Administrateur"]
  *     summary: Récupération des infos candidat
  *     description: L'administrateur récupère les informations d'un candidat via son id
- *     produces:
- *      - application/json
  *     security:
  *       - bearerAuth: []
  *     parameters:
@@ -183,7 +172,6 @@ router.get('/me', getMe)
  *         schema:
  *           type: number
  *           example: 93
- *         required: false
  *         description: Un département accessible par l'admin
  *     responses:
  *       200:
@@ -241,8 +229,6 @@ router.get(
  *     tags: ["Administrateur"]
  *     summary: Ajout des candidats
  *     description: Import des candidats via le fichier délivré par aurige. Nécessite les droits administrateur
- *     produces:
- *      - application/json
  *     security:
  *       - bearerAuth: []
  *     requestBody:
@@ -356,8 +342,6 @@ router.post(
  *     tags: ["Administrateur"]
  *     summary: Récupération des infos inspecteur
  *     description: L'administrateur récupère les informations d'un ou plusieurs inspecteurs
- *     produces:
- *      - application/json
  *     security:
  *       - bearerAuth: []
  *     parameters:
@@ -366,21 +350,18 @@ router.post(
  *         schema:
  *           type: string
  *           example: Dupont
- *         required: false
  *         description: Une chaîne de caractères pour chercher un inspecteur
  *       - in: query
  *         name: departement
  *         schema:
  *           type: number
  *           example: 93
- *         required: false
  *         description: S'il est entré comme seul paramètre, renvoie tous les inspecteurs d'un département
  *       - in: query
  *         name: centreId
  *         schema:
  *           type: string
  *           example: 5d8b7c6429cd5b2468d3f161
- *         required: false
  *         description:
  *           Remplir pour chercher les inspecteurs affectés à un centre pendant une période donnée.
  *           Ne fonctionne que si `begin` et `end` sont aussi paramétrés
@@ -389,7 +370,6 @@ router.post(
  *         schema:
  *           type: string
  *           example: 2019-09-25 14:40:36.724Z
- *         required: false
  *         description:
  *           Début de la période de recherche d'inspecteurs.
  *           Ne fonctionne que si `centreId` et `end` sont aussi paramétrés
@@ -398,7 +378,6 @@ router.post(
  *         schema:
  *           type: string
  *           example: 2019-09-25 14:40:36.724Z
- *         required: false
  *         description:
  *           Fin de la période de recherche d'inspecteurs.
  *           Ne fonctionne que si `centreId` et `begin` sont aussi paramétrés
@@ -483,8 +462,6 @@ router.get('/places', verifyRepartiteurDepartement, getPlaces)
  *     tags: ["Administrateur"]
  *     summary: Chargement du planning des inspecteurs
  *     description: Permet de charger le planning des inspecteurs pour le département actif de l'utilisateur
- *     produces:
- *       - application/json
  *     security:
  *       - bearerAuth: []
  *     requestBody:
@@ -515,13 +492,15 @@ router.get('/places', verifyRepartiteurDepartement, getPlaces)
  *                   type: string
  *                   description: Le nom de fichier en .csv ou .xlsx contenant les places
  *                 success:
- *                   type: boolean,
- *                   description: vaut true,
+ *                   type: boolean
+ *                   description: vaut true
  *                 message:
  *                   type: string
  *                   description: Un message compréhensible par l'usager
  *                 places:
  *                   type: array
+ *                   items:
+ *                     type: object
  *                   description: Les messages sur l'état de traitement des places
  *             example:
  *               fileName: planning-93.csv
@@ -584,8 +563,6 @@ router.post(
  *     tags: ["Administrateur"]
  *     summary: Récupération des statsKpi places
  *     description: Permet de récupérer les statistiques sur les places d'examens de chaque département.
- *     produces:
- *       - application/json
  *     parameters:
  *       - in: query
  *         name: isCsv
@@ -628,8 +605,6 @@ router.get(
  *     tags: ["Administrateur"]
  *     summary: Récupération des statsKpi de résultats d'examens sur une période passée
  *     description: Permet de récupérer les statistiques sur les places d'examens de chaque département.
- *     produces:
- *       - application/json
  *     parameters:
  *       - in: query
  *         name: beginPeriod
@@ -686,8 +661,6 @@ router.get(
  *     tags: ["Administrateur"]
  *     summary: Suppression d'un élément de la liste blanche
  *     description: L'administrateur supprime une adresse de la liste blanche à partir de son id
- *     produces:
- *      - application/json
  *     security:
  *       - bearerAuth: []
  *     parameters:
@@ -703,7 +676,6 @@ router.get(
  *         schema:
  *           type: number
  *           example: 93
- *         required: false
  *         description: Un département accessible par l'admin
  *
  *     responses:
@@ -747,8 +719,6 @@ router
  *     description:
  *       L'administrateur récupère une ou plusieures adresses de la liste blanche.
  *       Si le paramètre `matching` n'est pas entré, cela renvoie les dernières adresses rentrées dans la base
- *     produces:
- *      - application/json
  *     security:
  *       - bearerAuth: []
  *     parameters:
@@ -757,7 +727,6 @@ router
  *         schema:
  *           type: string
  *           example: dupont
- *         required: false
  *         description: Une chaîne de caractères pour chercher une adresse dans la liste blanche
  *
  *     responses:
@@ -788,8 +757,6 @@ router
  *     tags: ["Administrateur"]
  *     summary: Ajout d'éléments dans la liste blanche
  *     description: L'administrateur ajoute une ou plusieures adresses dans la liste blanche.
- *     produces:
- *      - application/json
  *     security:
  *       - bearerAuth: []
  *     requestBody:
@@ -830,8 +797,6 @@ router
  *                 - $ref: '#/components/schemas/WhitelistedInfo'
  *             examples:
  *               une seule adresse:
- *                 schema:
- *                   $ref: '#/components/schemas/WhitelistedObject'
  *                 value:
  *                   _id: 5d970a082a7710570f0fd7b8
  *                   email: candidat@candi.lib
@@ -949,8 +914,6 @@ router
  *     tags: ["Administrateur"]
  *     summary: Création d'un utilisateur
  *     description: Création d'un utilisateur. Seul un admin peut créer un délégué (il peut aussi créer un répartiteur) et seul un délégué peut créer un répartiteur.
- *     produces:
- *      - application/json
  *     security:
  *       - bearerAuth: []
  *     requestBody:
@@ -967,13 +930,15 @@ router
  *                 description: Email de l'utilisateur
  *               departements:
  *                 type: array
+ *                 items:
+ *                   type: string
+ *                   description: Département accessible par l'utilisateur
  *                 example: ["93"]
- *                 description: Département de l'utilisateur
+ *                 description: Départements de l'utilisateur
  *               status:
  *                 type: string
  *                 example: repartiteur
  *                 description: Statut de l'utilisateur
- *
  *
  *     responses:
  *       200:
@@ -1014,12 +979,9 @@ router
  *     tags: ["Administrateur"]
  *     summary: Récupération des informations de l'utilisateur
  *     description: Après connexion récupération de l'utilisateur. Seul un admin peut récupérer les informations d'un délégué (il peut aussi récupérer les informations d'un répartiteur) et seul un délégué peut récupérer les informations d'un répartiteur.
- *     produces:
- *      - application/json
  *     security:
  *       - bearerAuth: []
  *     requestBody:
- *       description:
  *       required: true
  *       content:
  *         application/json:
@@ -1032,17 +994,19 @@ router
  *                 description: Email de l'utilisateur
  *               departements:
  *                 type: array
+ *                 items:
+ *                   type: string
+ *                   description: Département accessible par l'utilisateur
  *                 example: ["93"]
- *                 description: Département de l'utilisateur
+ *                 description: Départements de l'utilisateur
  *               status:
  *                 type: string
  *                 example: repartiteur
  *                 description: Statut de l'utilisateur
  *
- *
  *     responses:
  *       200:
- *         description:
+ *         description: Succès de la requête
  *         content:
  *           application/json:
  *             schema:
@@ -1079,8 +1043,6 @@ router
  *     tags: ["Administrateur"]
  *     summary: Modification d'un utilisateur
  *     description: Modification d'un utilisateur. Seul un admin peut modifier un délégué (il peut aussi modifier un répartiteur) et seul un délégué peut modifier un répartiteur.
- *     produces:
- *      - application/json
  *     security:
  *       - bearerAuth: []
  *     requestBody:
@@ -1097,13 +1059,15 @@ router
  *                 description: Email de l'utilisateur
  *               departements:
  *                 type: array
+ *                 items:
+ *                   type: string
+ *                   description: Département accessible par l'utilisateur
  *                 example: ["93"]
- *                 description: Département de l'utilisateur
+ *                 description: Départements de l'utilisateur
  *               status:
  *                 type: string
  *                 example: repartiteur
  *                 description: Statut de l'utilisateur
- *
  *
  *     responses:
  *       200:
@@ -1144,8 +1108,6 @@ router
  *     tags: ["Administrateur"]
  *     summary: Suppression d'un utilisateur
  *     description: Supression d'un utilisateur. Seul un admin peut supprimer un délégué (il peut aussi supprimer un répartiteur) et seul un délégué peut supprimer un répartiteur.
- *     produces:
- *      - application/json
  *     security:
  *       - bearerAuth: []
  *     requestBody:
@@ -1162,13 +1124,15 @@ router
  *                 description: Email de l'utilisateur
  *               departements:
  *                 type: array
+ *                 items:
+ *                   type: string
+ *                   description: Département accessible par l'utilisateur
  *                 example: ["93"]
- *                 description: Département de l'utilisateur
+ *                 description: Départements de l'utilisateur
  *               status:
  *                 type: string
  *                 example: repartiteur
  *                 description: Statut de l'utilisateur
- *
  *
  *     responses:
  *       200:

--- a/server/src/routes/auth/index.js
+++ b/server/src/routes/auth/index.js
@@ -33,8 +33,6 @@ const router = express.Router()
  *   tags: ["Authentification", "Administrateur"]
  *   summary: Récupération d'un token pour un adminstrateur
  *   description: Vérifie le login et le mot de passe et retourne un token
- *   produces:
- *     - application/json
  *
  *   requestBody:
  *     required: true
@@ -52,7 +50,7 @@ const router = express.Router()
  *               type: string
  *               format: password
  *               description: Mot de passe de l'administrateur
- *           require:
+ *           required:
  *            - email
  *            - password
  *         example:
@@ -72,7 +70,7 @@ const router = express.Router()
  *                 token:
  *                   type: string
  *                   format: JWT
- *                   descritpion: le token de durée de 1 journée pour l'administrateur
+ *                   description: le token de durée de 1 journée pour l'administrateur
  *             example:
  *                success: true
  *                token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjVkOWIwNGRiMGIyNzlmMDAzYzY3NzEwZCIsImxldmVsIjoxLCJkZXBhcnRlbWVudHMiOlsiNzUiXSwiaWF0IjoxNTcxMDY1MTU5LCJleHAiOjE1NzEwOTc1OTh9.WwiOiujeCHKFIRqd0s8WPz_4fFzLlnkP3KL2ayftMHY"
@@ -118,16 +116,15 @@ const router = express.Router()
  *
  * /admin/reset-link:
  *   post:
+ *     tags: ["Administrateur"]
  *     summary: Envoi d'un mail pour réinitialiser son mot de passe
  *     description: Envoi d'un mail avec un lien vers un formulaire pour réinitialiser son mot de passe
- *     produces:
- *       - application/json
  *     security:
  *       - bearerAuth: []
  *
  *     responses:
  *       200:
- *         description:
+ *         description: Succès de la requête
  *         content:
  *           application/json:
  *             schema:
@@ -135,45 +132,7 @@ const router = express.Router()
  *                 - $ref: '#/components/schemas/InfoObject'
  *                 - example:
  *                     success: true
- *                     message: Un courriel vient de vous être envoyé sur email@example.com
- *
- *       404:
- *         $ref: '#/components/responses/InvalidEmailResponse'
- *
- *       500:
- *         $ref: '#/components/responses/UnknownErrorResponse'
- *
- */
-
-/**
- *
- * @see {@link http://localhost:8000/api-docs/#/default/post_admin_reset-link}
- */
-router.post('/admin/reset-link', requestPasswdReset)
-
-/**
- * @swagger
- *
- * /admin/reset-link:
- *   post:
- *     summary: Envoi d'un mail pour réinitialiser son mot de passe
- *     description: Envoi d'un mail avec un lien vers un formulaire pour réinitialiser son mot de passe
- *     produces:
- *       - application/json
- *     security:
- *       - bearerAuth: []
- *
- *     responses:
- *       200:
- *         description:
- *         content:
- *           application/json:
- *             schema:
- *               allOf:
- *                 - $ref: '#/components/schemas/InfoObject'
- *                 - example:
- *                     success: true
- *                     message: Un courriel vient de vous être envoyé sur email@example.com
+ *                     message: Un courriel vient de vous être envoyé sur email@exemple.fr
  *
  *       404:
  *         $ref: '#/components/responses/InvalidEmailResponse'
@@ -199,8 +158,6 @@ router.post('/admin/token', getAdminToken)
  *    tags: ["Authentification", "Administrateur"]
  *    summary: Vérifie que le jeton d'authentification est valide
  *    description: Vérife si le token de l'administrateur est valide et l'administrateur a les droits d'accès
- *    produces:
- *     - application/json
  *    security:
  *     - bearerAuth: []
  *    responses:
@@ -231,8 +188,6 @@ router.get(
  *   tags: ["Authentification", "Candidat"]
  *   summary: Envoie un lien de connexion par courriel
  *   description: Vérifie que le candidat à le droit de se connecter et lui envoie un e-mail avec un lien de connexion
- *   produces:
- *     - application/json
  *
  *   requestBody:
  *     required: true
@@ -246,7 +201,7 @@ router.get(
  *               type: string
  *               format: email
  *               description: adresse courriel du candidat
- *           require:
+ *           required:
  *            - email
  *         example:
  *            "email": "candilib.box-1@yahoo.com"
@@ -263,7 +218,7 @@ router.get(
  *                   description: vaut true
  *                 message:
  *                   type: string
- *                   descritpion: vaut 'Veuillez consulter votre boîte mail pour vous connecter (pensez à vérifier dans vos courriers indésirables).'
+ *                   description: vaut 'Veuillez consulter votre boîte mail pour vous connecter (pensez à vérifier dans vos courriers indésirables).'
  *             example:
  *                success: true
  *                message: 'Veuillez consulter votre boîte mail pour vous connecter (pensez à vérifier dans vos courriers indésirables).'
@@ -328,8 +283,6 @@ router.post('/candidat/magic-link', postMagicLink)
  *    tags: ["Authentification", "Candidat"]
  *    summary: Vérifie que le jeton d'authentification est valide
  *    description: Vérife si le token de l'administrateur est valide et l'administrateur a les droits d'accès
- *    produces:
- *     - application/json
  *    security:
  *     - bearerAuth: []
  *    responses:

--- a/server/src/routes/candidat/index.js
+++ b/server/src/routes/candidat/index.js
@@ -22,14 +22,12 @@ const router = express.Router()
  *     tags: ["Candidat"]
  *     summary: Récupération de mes infos candidat
  *     description: Après connexion, renvoie les infos du candidat connecté (id dans le JWT envoyé en header)
- *     produces:
- *      - application/json
  *     security:
  *       - bearerAuth: []
-
+ *
  *     responses:
  *       200:
- *         description:
+ *         description: Succès de la requête
  *         content:
  *           application/json:
  *             schema:
@@ -59,8 +57,6 @@ router.get('/me', getMe)
  *     tags: ["Candidat"]
  *     summary: Récupération de mes infos des centres du département du candidat
  *     description: Après connexion, renvoie les infos des centres du département du candidat
- *     produces:
- *      - application/json
  *     security:
  *       - bearerAuth: []
  *     parameters:
@@ -75,23 +71,21 @@ router.get('/me', getMe)
  *         name: nom
  *         schema:
  *           type: string
- *           example: 'Rosny-sous-Bois'
- *         required: false
+ *           example: Rosny-sous-Bois
  *         description: Nom d'un centre
  *       - in: query
  *         name: end
  *         schema:
  *           type: string
- *           example: 'Rosny-sous-Bois'
- *         required: false
+ *           example: 2019-09-10T22:00:00.000Z
  *         description: Date de fin de la fourchette de temps dans lequel les places seront cherchés
  *     responses:
  *       200:
- *         description:
+ *         description: Succès de la requête
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/CentresInfo'
+ *               $ref: '#/components/schemas/CenterObject'
  *
  *       400:
  *         description: Paramètre(s) manquant(s)
@@ -128,8 +122,6 @@ router.get('/centres', getCentres)
  *     tags: ["Candidat"]
  *     summary: Récupération de la réservation du candidat
  *     description: Après connexion, renvoie des informations de la réservation du candidat
- *     produces:
- *       - application/json
  *     security:
  *       - bearerAuth: []
  *     parameters:
@@ -198,8 +190,6 @@ router.get('/centres', getCentres)
  *     tags: ["Candidat"]
  *     summary: Récupération de mes infos des centres du département du candidat
  *     description: Après connexion, renvoie les dates places disponibles pour un centre du département du candidat sur une période ou à une date précise
- *     produces:
- *       - application/json
  *     security:
  *       - bearerAuth: []
  *     parameters:
@@ -208,21 +198,19 @@ router.get('/centres', getCentres)
  *         schema:
  *           type: string
  *           example: '5cf63145b2a7cffde20e98b7'
- *         required: false
+ *         required: true
  *         description: Identifiant d'un centre
  *       - in: query
  *         name: centre
  *         schema:
  *           type: string
  *           example: 'Rosny-sous-Bois'
- *         required: false
  *         description: Nom d'un centre
  *       - in: query
  *         name: departement
  *         schema:
  *           type: string
  *           example: '93'
- *         required: false
  *         description: Code département
  *       - in: query
  *         name: begin
@@ -235,23 +223,24 @@ router.get('/centres', getCentres)
  *         name: end
  *         schema:
  *           type: string
- *           example:
- *         required: false
+ *           example: 2019-09-10T22:00:00.000Z
  *         description: Date de fin de la fourchette de temps dans laquelle les places seront cherchées
  *       - in: query
  *         name: dateTime
  *         schema:
  *           type: string
  *           example:
- *         required: false
  *         description: Date du jour pour lequel l'API doit retourner les places
  *     responses:
  *       200:
- *         description:
+ *         description: Succès de la requête
  *         content:
  *           application/json:
  *             schema:
- *               type: Array
+ *               type: array
+ *               items:
+ *                 type: string
+ *                 description: date de la place
  *               example: ["2019-10-06T08:00:00.000+02:00","2019-10-06T08:30:00.000+02:00","2019-10-06T09:00:00.000+02:00"]
  *
  *       400:
@@ -298,8 +287,6 @@ router.get('/places/:id?', getPlaces)
  *      tags: ["Candidat"]
  *      summary: Réservation d'une place d'examen par le candidat
  *      description: Pour réserver ou modifier une réservation d'une place d'examen et envoie la convocation par e-mail
- *      produces:
- *        - application/json
  *      security:
  *        - bearerAuth: []
  *      requestBody:
@@ -312,7 +299,7 @@ router.get('/places/:id?', getPlaces)
  *              properties:
  *                id:
  *                  type: object
- *                  descritpion: Identifiant d'un centre
+ *                  description: Identifiant d'un centre
  *                  example: '5cf63145b2a7cffde20e98b7'
  *                date:
  *                  type: string
@@ -392,8 +379,6 @@ router.patch('/places', bookPlaceByCandidat)
  *      tags: ["Candidat"]
  *      summary: Annulation d'une réservation par un candidat
  *      description: Annuler une réservation d'une place d'examen et envoie l'e-mail d'annulation par le candidat
- *      produces:
- *        - application/json
  *      security:
  *        - bearerAuth: []
  *      responses:

--- a/server/src/routes/index.js
+++ b/server/src/routes/index.js
@@ -20,8 +20,6 @@ const router = express.Router()
  *     tags: ["Candidat"]
  *     summary: Pré-inscription du candidat sur l'application Candilib
  *     description: Ajoute un·e nouv·eau·elle candidat·e dans la base de données si les données envoyées sont correctes.
- *     produces:
- *      - application/json
  *
  *     requestBody:
  *       description: Données du formulaire de pré-inscription
@@ -30,35 +28,35 @@ const router = express.Router()
  *         application/json:
  *           schema:
  *             type: object
+ *             required:
+ *               - codeNeph
+ *               - nomNaissance
+ *               - email
+ *               - portable
+ *               - adresse
  *             properties:
  *               codeNeph:
  *                 description: NEPH du ou de la candidat·e
- *                 required: true
  *                 type: string
  *                 example: 123456789012
  *               nomNaissance:
  *                 description: Nom de naissance du ou de la candidat·e
- *                 required: true
  *                 type: string
  *                 example: Dupont
  *               prenom:
  *                 description: Prénom du ou de la candidat·e
- *                 required: false
  *                 type: string
  *                 example: Jean
  *               email:
  *                 description: Adresse email du ou de la candidat·e
- *                 required: true
  *                 type: string
  *                 example: jean@dupont.name
  *               portable:
  *                 description: Numéro de téléphone mobile du ou de la candidat·e
- *                 required: true
  *                 type: string
  *                 example: 0612345678
  *               adresse:
  *                 description: Adresse postale du ou de la candidat·e
- *                 required: true
  *                 type: string
  *                 example: 16 avenue du général Leclerc 75014 Paris
  *     responses:
@@ -126,8 +124,6 @@ router.post('/candidat/preinscription', preSignup)
  *     tags: ["Candidat"]
  *     summary: Validation de l'adresse courriel du candidat
  *     description: Vérification du hash unique correspondant à celui associé à cette adresse courriel dans la base de données Candilib.
- *     produces:
- *      - application/json
  *
  *     requestBody:
  *       description: Adresse courriel et hash de vérification
@@ -136,15 +132,16 @@ router.post('/candidat/preinscription', preSignup)
  *         application/json:
  *           schema:
  *             type: object
+ *             required:
+ *               - email
+ *               - hash
  *             properties:
  *               email:
  *                 description: Adresse email du ou de la candidat·e
- *                 required: true
  *                 type: string
  *                 example: jean@dupont.name
  *               hash:
  *                 description: Hash qui doit correspondre au hash stocké en base pour cette adresse courriel.
- *                 required: true
  *                 type: string
  *                 example: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed'
  *     responses:
@@ -159,7 +156,7 @@ router.post('/candidat/preinscription', preSignup)
  *                     success: true
  *                     message: Votre adresse courriel a été validée, veuillez consulter votre messagerie (pensez à vérifier dans vos courriers indésirables).
  *       404:
- *         description:
+ *         description: Adresse introuvable dans la base
  *         content:
  *           application/json:
  *             schema:
@@ -169,7 +166,7 @@ router.post('/candidat/preinscription', preSignup)
  *                     success: false
  *                     message: Votre adresse courriel est inconnue
  *       422:
- *         description:
+ *         description: Lien expiré
  *         content:
  *           application/json:
  *             schema:
@@ -179,7 +176,7 @@ router.post('/candidat/preinscription', preSignup)
  *                     success: false
  *                     message: Candidat 291029393029/Dupont courriel non vérifié depuis plus de 2h, vous devez refaire la pré-inscription
  *       500:
- *         description:
+ *         description: Erreur serveur inconnue
  *         content:
  *           application/json:
  *             schema:
@@ -203,10 +200,9 @@ router.put('/candidat/me', emailValidation)
  *
  * /admin/me:
  *   patch:
+ *     tags: ["Administrateur"]
  *     summary: Met à jour le mot de passe
  *     description: Met à jour le mot de passe de l'utilisateur si l'email et le hash correspondent, et que la réinitialisation a été demandé il y a moins de 15 minutes
- *     produces:
- *      - application/json
  *     security:
  *       - bearerAuth: []
  *
@@ -217,35 +213,32 @@ router.put('/candidat/me', emailValidation)
  *         application/json:
  *           schema:
  *             type: object
+ *             required:
+ *               - newPassword
+ *               - confirmNewPassword
+ *               - email
+ *               - hash
  *             properties:
  *               newPassword:
  *                 description: Nouveau mot de passe
- *                 required: true
  *                 type: string
  *                 example: M9se5p@7
  *               confirmNewPassword:
  *                 description: Confirmation du nouveau mot de passe
- *                 required: true
  *                 type: string
  *                 example: M9se5p@7
  *               email:
  *                 description: Email de l'utilisateur
- *                 required: true
  *                 type: string
- *                 example: example@example.fr
+ *                 example: exemple@exemple.fr
  *               hash:
  *                 description: hash d'identification de l'utilisateur
- *                 required: true
  *                 type: string
  *                 example: 9d0a2b5e-e143-11e9-81b4-2a2ae2dbcce4
  *
- *
- *
- *
- *
  *     responses:
  *       200:
- *         description:
+ *         description: Succès de la requête
  *         content:
  *           application/json:
  *             schema:


### PR DESCRIPTION
Corrections apportées à la doc swagger avec l'aide de [swagger editor](https://editor.swagger.io).

Modifications notables:
- `produces` n'est plus utilisé avec OpenAPI 3 (https://swagger.io/blog/news/whats-new-in-openapi-3-0/)
- Les types doivent être écris en minuscules (`array`, `object`...)
- `array` a besoin d'être décrit par `items`
- `required: false` n'a pas besoin d'être précisé
- Remplace `require` en `required`
- Les paramètres `in: path` sont forcément `required: true` (https://swagger.io/specification/#parameterObject)
- Tags décrit au format yaml pour rester cohérent
- `required` est une catégorie à part dans `schema` et doit être décrit au même niveau que `properties`

Et d'autres modifications plus explicites. (Comme remplacer `decritpion` par `description`)