### PR TITLE
Fix e2e test disconnect candidate

### DIFF
--- a/client/tests/e2e/specs/candidateFront.js
+++ b/client/tests/e2e/specs/candidateFront.js
@@ -132,6 +132,7 @@ describe('Connected candidate front', () => {
       'contain',
       'Merci de noter Candilib',
     )
+    cy.wait(1000)
     cy.get('.t-evaluation-submit').click()
   })
 


### PR DESCRIPTION
Il semblerait qu'ajouter un wait avant de cliquer sur "Noter maintenant" corrige bel et bien le bug.