### PR TITLE
Add api access limitations (nginx)

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -100,5 +100,12 @@ NPM_AUDIT_DRY_RUN  := $(shell echo $$NPM_AUDIT_DRY_RUN )
 # Run env
 LINE_DELAY := $(shell [ -n "$$LINE_DELAY" ] && echo $$LINE_DELAY )
 
+# Reverse proxy (nginx)
+API_USER_SCOPE=http_x_forwarded_for
+API_USER_LIMIT_RATE=10r/s
+API_USER_BURST=5 nodelay
+APP_USER_LIMIT_RATE=30r/s
+APP_USER_BURST=80 nodelay
+
 # export all variables in subshell
 export

--- a/client/docker-compose.prod.front.yml
+++ b/client/docker-compose.prod.front.yml
@@ -25,6 +25,11 @@ services:
       API_HOST: ${API_HOST:-api}
       API_PORT: ${API_PORT:-8000}
       LINE_DELAY: ${LINE_DELAY}
+      API_USER_SCOPE: ${API_USER_SCOPE}
+      API_USER_LIMIT_RATE: ${API_USER_LIMIT_RATE}
+      API_USER_BURST: ${API_USER_BURST}
+      APP_USER_LIMIT_RATE: ${APP_USER_LIMIT_RATE}
+      APP_USER_BURST: ${API_USER_BURST}
     ports:
       - "${FRONT_CANDIDAT_PORT:-80}:80"
     restart: always
@@ -52,6 +57,11 @@ services:
     environment:
       API_HOST: ${API_HOST:-candilib_api}
       API_PORT: ${API_PORT:-8000}
+      API_USER_SCOPE: ${API_USER_SCOPE}
+      API_USER_LIMIT_RATE: ${API_USER_LIMIT_RATE}
+      API_USER_BURST: ${API_USER_BURST}
+      APP_USER_LIMIT_RATE: ${APP_USER_LIMIT_RATE}
+      APP_USER_BURST: ${API_USER_BURST}
     ports:
       - "${FRONT_ADMIN_PORT:-80}:80"
     restart: always

--- a/client/nginx/nginx-run-admin.template
+++ b/client/nginx/nginx-run-admin.template
@@ -11,6 +11,11 @@ server {
     try_files $uri @rew;
   }
 
+  location /robots.txt {
+    expires 24h;
+    return 200 "User-agent: *\nDisallow: <PUBLIC_PATH>/api/\nAllow: /";
+  }
+
   location @rew {
     expires 24h;
     if ($http_x_forwarded_proto) {

--- a/client/nginx/nginx-run-candidat.template
+++ b/client/nginx/nginx-run-candidat.template
@@ -9,6 +9,11 @@ server {
     try_files $uri @rew;
   }
 
+  location /robots.txt {
+    expires 24h;
+    return 200 "User-agent: *\nDisallow: <PUBLIC_PATH>/api/\nAllow: /";
+  }
+
   location @rew {
     expires 24h;
     if ($http_x_forwarded_proto) {
@@ -19,6 +24,8 @@ server {
 
   location <PUBLIC_PATH> {
     expires 24h;
+    limit_req zone=app burst=<APP_USER_BURST>;
+    limit_req_status 429;
     alias /usr/share/nginx/html;
     try_files $uri $uri/ @rewrites;
 
@@ -33,6 +40,8 @@ server {
   }
 
   location ~ "^<PUBLIC_PATH>/api/v2/candidat" {
+    limit_req zone=api burst=<API_USER_BURST>;
+    limit_req_status 429;
     rewrite "^<PUBLIC_PATH>(.*)$" $1 break;
     add_header Access-Control-Allow-Origin '$http_origin';
     proxy_pass http://<API_HOST>:<API_PORT>;
@@ -41,6 +50,8 @@ server {
     proxy_http_version 1.1;
   }
   location ~ "^<PUBLIC_PATH>/api/v2/auth/candidat" {
+    limit_req zone=api burst=<API_USER_BURST>;
+    limit_req_status 429;
     rewrite "^<PUBLIC_PATH>(.*)$" $1 break;
     add_header Access-Control-Allow-Origin '$http_origin';
     proxy_pass http://<API_HOST>:<API_PORT>;

--- a/client/nginx/nginx.template
+++ b/client/nginx/nginx.template
@@ -15,6 +15,10 @@ http {
     default_type  application/octet-stream;
 
     server_tokens off;
+
+    limit_req_zone $<API_USER_SCOPE> zone=app:10m rate=<APP_USER_LIMIT_RATE>;
+    limit_req_zone $<API_USER_SCOPE> zone=api:2m rate=<API_USER_LIMIT_RATE>;
+
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-Frame-Options SAMEORIGIN;
     add_header X-Content-Type-Options nosniff;

--- a/client/nginx/run.sh
+++ b/client/nginx/run.sh
@@ -19,13 +19,19 @@ EOF
 fi
 
 # Set nginx env variables
-[ -z "${APP}" -o -z "${API_HOST}" -o -z "${API_PORT}" ] && exit 1
+[ -z "${APP}" -o -z "${API_HOST}" -o -z "${API_PORT}" \
+  -o -z "${API_USER_SCOPE}" -o -z "${API_USER_LIMIT_RATE}" -o -z "${API_USER_BURST}" -o -z "${APP_USER_LIMIT_RATE}" ] \
+  && exit 1
 (
  cat /etc/nginx/conf.d/default.template | \
- sed "s/<APP>/${APP}/g;s/<API_HOST>/${API_HOST}/g;s/<API_PORT>/${API_PORT}/g;" |
+ sed "s#<APP>#${APP}#g;s#<API_HOST>#${API_HOST}#g;s#<API_PORT>#${API_PORT}#g;" |
+ sed "s#<API_USER_SCOPE>#${API_USER_SCOPE}#g;s#<API_USER_LIMIT_RATE>#${API_USER_LIMIT_RATE}#g;s#<API_USER_BURST>#${API_USER_BURST}#g;s#<APP_USER_LIMIT_RATE>#${APP_USER_LIMIT_RATE}#g;s#<APP_USER_BURST>#${APP_USER_BURST}#g;" |
  sed "/^server {/a\
 error_log /dev/stderr warn;\
 access_log /dev/stdout main;
 " > /etc/nginx/conf.d/default.conf
-cat /etc/nginx/nginx.template > /etc/nginx/nginx.conf
+cat /etc/nginx/nginx.template |
+ sed "s#<APP>#${APP}#g;s#<API_HOST>#${API_HOST}#g;s#<API_PORT>#${API_PORT}#g;" |
+ sed "s#<API_USER_SCOPE>#${API_USER_SCOPE}#g;s#<API_USER_LIMIT_RATE>#${API_USER_LIMIT_RATE}#g;s#<API_USER_BURST>#${API_USER_BURST}#g;s#<APP_USER_LIMIT_RATE>#${APP_USER_LIMIT_RATE}#g;s#<APP_USER_BURST>#${APP_USER_BURST}#g;" > /etc/nginx/nginx.conf
+
 ) && nginx -g "daemon off;"


### PR DESCRIPTION
* Add api access limitation (nginx): per unique IP, limit request/s and burst
```
API_USER_SCOPE=http_x_forwarded_for
# /api
API_USER_LIMIT_RATE=10r/s
API_USER_BURST=5 nodelay
# /
APP_USER_LIMIT_RATE=30r/s
APP_USER_BURST=80 nodelay
```
* robots.txt:
```
Disallow: <PUBLIC_PATH>/api/
Allow: /
```