### PR TITLE
e2e launch docker cypress extra args with shell var CYPRESS_ARG

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -107,5 +107,8 @@ API_USER_BURST=15 nodelay
 APP_USER_LIMIT_RATE=30r/s
 APP_USER_BURST=80 nodelay
 
+# e2e
+
+CYPRESS_ARG  := $(shell echo $$CYPRESS_ARG )
 # export all variables in subshell
 export

--- a/client/docker-compose.e2e.yml
+++ b/client/docker-compose.e2e.yml
@@ -33,6 +33,7 @@ services:
       HTTP_PROXY: ${http_proxy}
       HTTPS_PROXY: ${http_proxy}
       NO_PROXY: ${no_proxy},candidat.candilib.local,admin.candilib.local,mailhog
+    entrypoint: ["/e2e-entrypoint.sh","$CYPRESS_ARG"]
     volumes:
       - ./tests/e2e/:/app/tests/e2e/
 

--- a/client/e2e-entrypoint.sh
+++ b/client/e2e-entrypoint.sh
@@ -8,4 +8,4 @@ npm config delete proxy
 npm config delete https-proxy
 npm config delete no-proxy
 
-npm run cypress -- --browser chrome
+npm run cypress -- --browser chrome $@


### PR DESCRIPTION
e2e: launch docker cypress with extra args through shell var CYPRESS_ARG=" --spec tests/e2e/specs/File.js"