### PR TITLE
Increase burst limit to 15 rq for API zone

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -103,7 +103,7 @@ LINE_DELAY := $(shell [ -n "$$LINE_DELAY" ] && echo $$LINE_DELAY )
 # Reverse proxy (nginx)
 API_USER_SCOPE=http_x_forwarded_for
 API_USER_LIMIT_RATE=10r/s
-API_USER_BURST=5 nodelay
+API_USER_BURST=15 nodelay
 APP_USER_LIMIT_RATE=30r/s
 APP_USER_BURST=80 nodelay
 


### PR DESCRIPTION
Increase burst limit to 15 rq for API zone