### PR TITLE
Tech/fix/test e2e candidat login clear token

### DIFF
--- a/client/tests/e2e/specs/candidateLogin.js
+++ b/client/tests/e2e/specs/candidateLogin.js
@@ -26,10 +26,12 @@ describe('Candidate login', () => {
 
   it('Create an account and verify line delay mail', () => {
     // The candidate fills the pre-sign-up form
-    cy.clearLocalStorage()
-    cy.visit(Cypress.env('frontCandidat') + 'candidat-presignup')
-
-    cy.wait(5000)
+    cy.visit(Cypress.env('frontCandidat') + 'candidat-presignup',{
+      onBeforeLoad: (win) => {
+        win.localStorage.clear()
+      }
+    })
+    
     cy.get('.t-presignup-form').within(($inForm) => {
       cy.get('label').eq(0).should('contain', 'NEPH')
       cy.get('input').eq(0)

--- a/client/tests/e2e/support/mailHogCommands.js
+++ b/client/tests/e2e/support/mailHogCommands.js
@@ -8,6 +8,7 @@ Cypress.Commands.add('deleteAllMails', () => {
 })
 
 Cypress.Commands.add('getLastMail', (infos) => {
+  cy.wait(100)
   cy.request({
     method: 'GET',
     url: mhApiUrl('/v2/messages?limit=10'),


### PR DESCRIPTION
Vides le localstorage quand cy.visit est déclenché sur la page pre-signup du candidat