### PR TITLE
Devops/upgrade node slim 12.16

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -131,7 +131,7 @@ heroku container:release web --app $HEROKU_APP
 BRANCH_DIR=$(echo "$BRANCH" |tr '/' '-')
 GIT_REMOTE_URL=$(git config --get remote.origin.url | sed -e 's/.git$//g')
 echo "Start db setup init"
-heroku run --no-tty -a $HEROKU_APP "set -ex ; ( cd /app && node ci/wget.js ${GIT_REMOTE_URL}/archive/${BRANCH}.tar.gz && tar -zxvf $(basename ${BRANCH}.tar.gz) --strip-components=2 candilibV2-${BRANCH_DIR}/server/dev-setup ) && npm run dev-setup"
+heroku run --no-tty -a $HEROKU_APP /bin/bash -c "set -ex ; ( cd /app && node ci/wget.js ${GIT_REMOTE_URL}/archive/${BRANCH}.tar.gz && tar -zxvf $(basename ${BRANCH}.tar.gz) --strip-components=2 candilibV2-${BRANCH_DIR}/server/dev-setup ) && npm run dev-setup"
 res=$?
 echo "End db setup init"
 # TODO: variable REPO

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -130,8 +130,10 @@ heroku container:release web --app $HEROKU_APP
 # first time : setup DB
 BRANCH_DIR=$(echo "$BRANCH" |tr '/' '-')
 GIT_REMOTE_URL=$(git config --get remote.origin.url | sed -e 's/.git$//g')
-heroku run --no-tty -a $HEROKU_APP "set -e ; ( cd /app && wget  -L ${GIT_REMOTE_URL}/archive/${BRANCH}.tar.gz -O - |tar zxvf - --strip-components=2 candilibV2-${BRANCH_DIR}/server/dev-setup ) && npm run dev-setup"
+echo "Start db setup init"
+heroku run --no-tty -a $HEROKU_APP "set -ex ; ( cd /app && node ci/wget.js ${GIT_REMOTE_URL}/archive/${BRANCH}.tar.gz && tar -zxvf $(basename ${BRANCH}.tar.gz) --strip-components=2 candilibV2-${BRANCH_DIR}/server/dev-setup ) && npm run dev-setup"
 res=$?
+echo "End db setup init"
 # TODO: variable REPO
 if  [ "$res" -gt 0 ] ; then
    exit $res

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,7 +1,7 @@
 #######################
 # Step 1: Base target #
 #######################
-FROM node:12.13.1-slim as base
+FROM node:12.16.1-slim as base
 ARG http_proxy
 ARG https_proxy
 ARG npm_registry

--- a/client/e2e.Dockerfile
+++ b/client/e2e.Dockerfile
@@ -1,7 +1,7 @@
 #######################
 # Step 1: Base target #
 #######################
-FROM cypress/browsers:node12.4.0-chrome76 as base
+FROM cypress/browsers:node12.16.1-chrome80-ff73 as base
 ARG http_proxy
 ARG https_proxy
 ARG npm_registry

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,7 @@
 #######################
 # Step 1: Base target #
 #######################
-FROM node:12.13.1-slim as base
+FROM node:12.16.1-slim as base
 ARG http_proxy
 ARG https_proxy
 ARG npm_registry

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -26,11 +26,14 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo "Europe/Paris" > /etc
 # Step 2: "development" target #
 ################################
 FROM base as development
+ARG MIRROR_DEBIAN
 ARG APP_VERSION
 COPY src src/
 COPY babel.config.js package.json package-lock.json ./
 # Install package utils for development
-RUN apt-get update && apt-get install -y libcurl3 libssl1.1 --no-install-recommends  
+RUN (set -x && [ -z "$MIRROR_DEBIAN" ] || sed -i.orig -e "s|http://deb.debian.org\([^[:space:]]*\)|$MIRROR_DEBIAN/debian9|g ; s|http://security.debian.org\([^[:space:]]*\)|$MIRROR_DEBIAN/debian9-security|g" /etc/apt/sources.list) ; \
+      buildPkgs="libcurl3 libssl1.1" ; \
+      apt-get update && apt-get install -y --no-install-recommends $buildPkgs
 # Install app dependencies
 RUN npm --no-git-tag-version version ${APP_VERSION} ; npm ci
 ENV NODE_ICU_DATA="/app/node_modules/full-icu"
@@ -45,6 +48,9 @@ FROM development as build
 ENV NPM_CONFIG_LOGLEVEL warn
 # Transpile the code with babel
 RUN npm run build
+RUN buildPkgs="libcurl3 libssl1.1" ; \
+      apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildPkgs ; \
+      rm -rf /var/lib/apt/lists/* # remove the cached files
 
 ###############################
 # Step 4: "production" target #
@@ -60,7 +66,6 @@ COPY ci ci/
 COPY ecosystem.config.js .
 # Copy the transpiled code to use in production (in /app)
 COPY --from=build /app/dist ./dist
-RUN apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 # Install production dependencies and clean cache
 RUN unset NODE_ICU_DATA && \
     npm --no-git-tag-version version ${APP_VERSION} && \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -29,6 +29,8 @@ FROM base as development
 ARG APP_VERSION
 COPY src src/
 COPY babel.config.js package.json package-lock.json ./
+# Install package utils for development
+RUN apt-get update && apt-get install -y libcurl3 libssl1.1 --no-install-recommends  
 # Install app dependencies
 RUN npm --no-git-tag-version version ${APP_VERSION} ; npm ci
 ENV NODE_ICU_DATA="/app/node_modules/full-icu"
@@ -57,6 +59,7 @@ COPY package.json package-lock.json ./
 COPY ecosystem.config.js .
 # Copy the transpiled code to use in production (in /app)
 COPY --from=build /app/dist ./dist
+RUN apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 # Install production dependencies and clean cache
 RUN unset NODE_ICU_DATA && \
     npm --no-git-tag-version version ${APP_VERSION} && \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -55,6 +55,7 @@ ARG NPM_AUDIT_DRY_RUN
 ENV NODE_ENV=production
 ARG APP_VERSION
 COPY package.json package-lock.json ./
+COPY ci ci/
 # Copy the pm2 config
 COPY ecosystem.config.js .
 # Copy the transpiled code to use in production (in /app)

--- a/server/ci/curl.js
+++ b/server/ci/curl.js
@@ -1,9 +1,10 @@
 
-const https = require('https')
 const lengthArgv = process.argv.length
 const url = process.argv[lengthArgv - 1]
 
-https.get(url, (res) => {
+const http = url.startsWith('https') ? require('https') : require('http')
+
+http.get(url, (res) => {
   let rawData = ''
   res.on('data', (chunk) => { rawData += chunk })
   res.on('end', () => {

--- a/server/ci/wget.js
+++ b/server/ci/wget.js
@@ -1,9 +1,9 @@
 
-const https = require('https')
 const fs = require('fs')
 
 const lengthArgv = process.argv.length
 const url = process.argv[lengthArgv - 1]
+const https = url.startsWith('https') ? require('https') : require('http')
 const paths = url.split('/')
 const fileName = paths[paths.length - 1]
 const writeStream = fs.createWriteStream(`./${fileName}`)

--- a/server/docker-compose.prod.api.yml
+++ b/server/docker-compose.prod.api.yml
@@ -13,6 +13,7 @@ services:
         https_proxy: ${http_proxy}
         no_proxy: ${no_proxy}
         npm_registry: ${NPM_REGISTRY}
+        MIRROR_DEBIAN: ${MIRROR_DEBIAN}
         NPM_AUDIT_DRY_RUN: ${NPM_AUDIT_DRY_RUN}
         APP_VERSION: ${APP_VERSION}
     ports:

--- a/tests/test-up-api.sh
+++ b/tests/test-up-api.sh
@@ -16,7 +16,7 @@ timeout=120;
 test_result=1
 dirname=$(dirname $0)
 until [ "$timeout" -le 0 -o "$test_result" -eq "0" ] ; do
-	${DC} -f ${DC_APP_API_RUN_PROD} exec ${DC_USE_TTY} $container_name curl --retry-max-time 120 --retry-delay 1  --retry 1 --fail -s http://localhost:8000/api/v2/version
+	${DC} -f ${DC_APP_API_RUN_PROD} exec ${DC_USE_TTY} $container_name node ci/curl.js --retry-max-time 120 --retry-delay 1  --retry 1 --fail -s http://localhost:8000/api/v2/version
 	test_result=$?
 	echo "Wait $timeout seconds: ${APP}-$container_name up $test_result";
 	(( timeout-- ))


### PR DESCRIPTION
Upgrading node slim 12.16 as the following impact, curl and wget are removed from default image.
And mongodb need libcurl/libssl 
and curl/wget are used in "ci deploy scripts" and "test up scripts"
- [X] upgrade node slim 12.16
- [X] replace curl with wrapper curl.js (used in tests/test-up-api.sh)
- [X] replace wget with wrapper wget.js (used in ci/deploy.sh to download and init db-setup on CI)
- [x] libcurl/libssl debian pkg (mongodb + mongodb-memory-server dependencies)
- [x] default apt conf to pass internal http proxy