### PR TITLE
Explicitly disable logs file in pm2 docker container in cluster mode

### DIFF
--- a/server/ecosystem.config.js
+++ b/server/ecosystem.config.js
@@ -6,6 +6,10 @@ module.exports = {
     exec_mode: 'cluster',
     // Options reference: https://pm2.io/doc/en/runtime/reference/ecosystem-file/
     autorestart: true,
+    log_file: '/dev/null',
+    out_file: '/dev/null',
+    error_file: '/dev/null',
+    merge_logs: true,
     env: {
       NODE_ENV: 'development',
     },


### PR DESCRIPTION
Explicitly disable logs file in pm2 docker container in cluster mode (seems to be a bug)